### PR TITLE
refactor: use `jackson` in `trace-diff`

### DIFF
--- a/trace-diff/pom.xml
+++ b/trace-diff/pom.xml
@@ -22,6 +22,11 @@
 
   <dependencies>
     <dependency>
+      <groupId>se.assertkth</groupId>
+      <artifactId>collector-sahab-commons</artifactId>
+      <version>${pom.parent.version}</version>
+    </dependency>
+    <dependency>
       <groupId>org.kohsuke</groupId>
       <artifactId>github-api</artifactId>
       <version>1.314</version>
@@ -42,9 +47,8 @@
       <version>4.0.0</version>
     </dependency>
     <dependency>
-      <groupId>com.googlecode.json-simple</groupId>
-      <artifactId>json-simple</artifactId>
-      <version>1.1.1</version>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>

--- a/trace-diff/src/test/java/se/assertkth/tracediff/computer/StateDiffComputerTest.java
+++ b/trace-diff/src/test/java/se/assertkth/tracediff/computer/StateDiffComputerTest.java
@@ -9,7 +9,6 @@ import java.nio.file.Paths;
 import java.util.*;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.tuple.Pair;
-import org.json.simple.parser.ParseException;
 import org.junit.jupiter.api.Test;
 import se.assertkth.tracediff.statediff.computer.StateDiffComputer;
 import se.assertkth.tracediff.statediff.models.ProgramStateDiff;
@@ -18,7 +17,7 @@ public class StateDiffComputerTest<R> {
 
     // data from https://github.com/khaes-kth/drr-execdiff/commit/649e9234549d2c74f1279499011da87638c2d718, depth=3
     @Test
-    void computeStateDiff_simple_diffIsGenerated() throws IOException, ParseException {
+    void computeStateDiff_simple_diffIsGenerated() throws IOException {
         Path simpleSahabDirectory = Paths.get("src/test/resources/sahab_reports/simple");
         File leftSahabReport = simpleSahabDirectory.resolve("report/left.json").toFile(),
                 rightSahabReport =
@@ -65,7 +64,7 @@ public class StateDiffComputerTest<R> {
     // breakpoint from: https://github.com/khaes-kth/drr-execdiff/commit/1c04679173a46faa59e73f68def33f60843f8beb
     // only a part of breakpoint data is stored in right.json
     @Test
-    void computeStateDiff_complex_diffIsGenerated() throws IOException, ParseException {
+    void computeStateDiff_complex_diffIsGenerated() throws IOException {
         Path simpleSahabDirectory = Paths.get("src/test/resources/sahab_reports/complex");
         File leftSahabReport = simpleSahabDirectory.resolve("report/left.json").toFile(),
                 rightSahabReport =
@@ -109,7 +108,7 @@ public class StateDiffComputerTest<R> {
     // depth=1
     // only a part of breakpoint data is stored in right.json
     @Test
-    void computeStateDiff_simple_diffIsGenerated_two() throws IOException, ParseException {
+    void computeStateDiff_simple_diffIsGenerated_two() throws IOException {
         Path simpleSahabDirectory = Paths.get("src/test/resources/sahab_reports/simple_two");
         File leftSahabReport = simpleSahabDirectory.resolve("report/left.json").toFile(),
                 rightSahabReport =


### PR DESCRIPTION
Fixes #151

@khaes-kth We now use `jackson` to deserialise the traces, and we use the APIs provided by the `commons` module. Just look at the difference in the tests :open_mouth: :

### Old
![Screenshot from 2023-04-12 17-01-04](https://user-images.githubusercontent.com/35191225/231500305-66858c80-6561-448b-900c-2f943b8b7560.png)

### New
![Screenshot from 2023-04-12 17-02-19](https://user-images.githubusercontent.com/35191225/231500344-e17f60bb-16b7-46c5-be10-5aa350c54214.png)

It can be further improved by skipping deserialisation and directly using the Java object passed by the agent. 
