### PR TITLE
fix: add more attributes to prevent build from failing

### DIFF
--- a/main/src/test/resources/surefire/modify-attributes.xml
+++ b/main/src/test/resources/surefire/modify-attributes.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.example</groupId>
+  <artifactId>basic-math</artifactId>
+  <version>1.0-SNAPSHOT</version>
+
+  <properties>
+    <maven.compiler.source>11</maven.compiler.source>
+    <maven.compiler.target>11</maven.compiler.target>
+  </properties>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>3.0.0</version>
+        <configuration>
+          <argLine>-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005</argLine>
+          <failIfNoTests>true</failIfNoTests>
+          <testFailureIgnore>false</testFailureIgnore>
+          <failIfNoSpecifiedTests>true</failIfNoSpecifiedTests>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>


### PR DESCRIPTION
Prevent build failure. While running the following command,
```bash
java -jar main/target/collector-sahab-0.0.1-SNAPSHOT-jar-with-dependencies.jar -p /tmp/cdk -l 5a7d75b -r d500be0677e151987be97d83a77054c91feebbe6 -c base/standard/src/main/java/org/openscience/cdk/tools/HOSECodeGenerator.java --slug cdk/cdk --execution-depth 3 --selected-tests org.openscience.cdk.reaction.type.RadicalSiteHrBetaReactionTest::testInitiate_IAtomContainerSet_IAtomContainerSet --output-path cdk_3.html 
```

The build failed, and it exited because it could not find the specified test in the module which is weird. We have set `failIfNoTests` as `false` so if it did not find a test, it should continue finding test in the other modules.