### PR TITLE
fix: force fetching of agent

### DIFF
--- a/trace-collector/src/main/java/se/assertkth/collector/util/JavaAgentPath.java
+++ b/trace-collector/src/main/java/se/assertkth/collector/util/JavaAgentPath.java
@@ -17,10 +17,6 @@ public class JavaAgentPath {
         String tempDir = System.getProperty("java.io.tmpdir");
         Path traceCollector = Path.of(tempDir, "trace-collector.jar");
 
-        if (Files.exists(traceCollector)) {
-            return traceCollector.toAbsolutePath().toString();
-        }
-
         try (InputStream traceCollectorStream = CollectorAgent.class.getResourceAsStream("/trace-collector.jar")) {
             Files.copy(traceCollectorStream, traceCollector, StandardCopyOption.REPLACE_EXISTING);
         }


### PR DESCRIPTION
We should not cache the JAR because in a development environment the agent can keep changing, but still the main module would fetch the cached (old) version of the agent.