### PR TITLE
fix: print canonical class name instead of toString representation

### DIFF
--- a/commons/src/main/java/se/assertkth/cs/commons/util/Classes.java
+++ b/commons/src/main/java/se/assertkth/cs/commons/util/Classes.java
@@ -97,27 +97,6 @@ public class Classes {
             }
             return value.toString();
         }
-        if (hasImplementedToString(value.getClass())) {
-            return value.toString();
-        }
         return getCanonicalClassName(value.getClass());
-    }
-
-    /**
-     * Returns whether the type declares `toString`.
-     */
-    public static boolean hasImplementedToString(Class<?> type) {
-        try {
-            if (type == null) {
-                return false;
-            }
-            if (!CACHED_CLASSES.containsKey(type)) {
-                CACHED_CLASSES.put(type, type.getMethod("toString").getDeclaringClass() != Object.class);
-            }
-
-            return CACHED_CLASSES.get(type);
-        } catch (NoSuchMethodException e) {
-            throw new AssertionError("Unreachable", e);
-        }
     }
 }

--- a/trace-collector/src/test/java/NewCollectorTest.java
+++ b/trace-collector/src/test/java/NewCollectorTest.java
@@ -1,6 +1,5 @@
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
@@ -312,7 +311,6 @@ class NewCollectorTest {
 
             List<?> atomicValue = (List<?>) elementsOfList.getValue();
             assertThat(atomicValue, equalTo(List.of(1, 2, 3, 4, 5)));
-            assertThat(list.getValue(), equalTo(List.of(1, 2, 3, 4, 5).toString()));
 
             // set
             RuntimeValue set =
@@ -320,12 +318,11 @@ class NewCollectorTest {
             assertThat(set.getName(), equalTo("set"));
             RuntimeValue elementsOfSet = set.getFields().get(1);
 
-            List<?> atomicValuesInSet = (List<?>) elementsOfSet.getValue();
+            assertThat(elementsOfSet.getName(), equalTo("elements"));
             // null are pre-allocated buffers in HashSet
-            assertThat(atomicValuesInSet, containsInAnyOrder("aman", "sharma", "sahab", null, null, null));
-            assertThat((String) set.getValue(), containsString("sahab"));
-            assertThat((String) set.getValue(), containsString("aman"));
-            assertThat((String) set.getValue(), containsString("sharma"));
+            assertThat(
+                    (List<?>) elementsOfSet.getValue(),
+                    containsInAnyOrder("aman", "sharma", "sahab", null, null, null));
         }
 
         @Test
@@ -779,11 +776,23 @@ class NewCollectorTest {
 
             RuntimeValue argument1 = returnValue.getArguments().get(0);
             assertThat(argument1.getName(), equalTo("a"));
-            assertThat(argument1.getValue(), equalTo("1/1"));
+
+            List<RuntimeValue> a1Fields = argument1.getFields();
+            assertThat(a1Fields.size(), equalTo(2));
+            assertThat(a1Fields.get(0).getName(), equalTo("numerator"));
+            assertThat(a1Fields.get(0).getValue(), equalTo(1));
+            assertThat(a1Fields.get(1).getName(), equalTo("denominator"));
+            assertThat(a1Fields.get(1).getValue(), equalTo(1));
 
             RuntimeValue argument2 = returnValue.getArguments().get(1);
             assertThat(argument2.getName(), equalTo("b"));
-            assertThat(argument2.getValue(), equalTo("1/4"));
+
+            List<RuntimeValue> a2Fields = argument2.getFields();
+            assertThat(a2Fields.size(), equalTo(2));
+            assertThat(a2Fields.get(0).getName(), equalTo("numerator"));
+            assertThat(a2Fields.get(0).getValue(), equalTo(1));
+            assertThat(a2Fields.get(1).getName(), equalTo("denominator"));
+            assertThat(a2Fields.get(1).getValue(), equalTo(4));
         }
     }
 


### PR DESCRIPTION
We print the canonical class name instead of `toString` representation.

### Old

![image](https://user-images.githubusercontent.com/35191225/232101712-ee612009-e68a-4cc7-b755-8f8e8ff81eef.png)

### New

![image](https://user-images.githubusercontent.com/35191225/232101773-fb81e765-0fdf-4618-a70c-0439a39bafa0.png)
