### PR TITLE
fix: append `.` to array element

### DIFF
--- a/trace-diff/src/main/java/se/assertkth/tracediff/statediff/computer/StateDiffComputer.java
+++ b/trace-diff/src/main/java/se/assertkth/tracediff/statediff/computer/StateDiffComputer.java
@@ -335,7 +335,7 @@ public class StateDiffComputer {
 
             for (int i = 0; i < nestedTypes.size(); i++) {
                 RuntimeValue nestedObj = nestedTypes.get(i);
-                String currentPrefix = prefix + "[" + i + "]";
+                String currentPrefix = prefix + "[" + i + "].";
                 varVals.addAll(extractVarVals(currentPrefix, nestedObj));
             }
         } else {


### PR DESCRIPTION
We have a `.` after value name in visualization. Example:

![image](https://user-images.githubusercontent.com/35191225/232109902-7f5151d6-a9af-424d-909d-bd018a9880ff.png)
