### PR TITLE
chore: debloat main module

### DIFF
--- a/main/pom.xml
+++ b/main/pom.xml
@@ -25,13 +25,6 @@
       <artifactId>trace-diff</artifactId>
       <version>${project.parent.version}</version>
     </dependency>
-    <!-- We only need this to get the JAR from resources -->
-    <!-- Inspiration: https://github.com/jacoco/jacoco/tree/master/org.jacoco.agent -->
-    <dependency>
-      <groupId>se.assertkth</groupId>
-      <artifactId>trace-collector</artifactId>
-      <version>${project.parent.version}</version>
-    </dependency>
 
     <dependency>
       <groupId>info.picocli</groupId>

--- a/main/src/main/java/se/assertkth/cs/preprocess/JavaAgentPath.java
+++ b/main/src/main/java/se/assertkth/cs/preprocess/JavaAgentPath.java
@@ -1,0 +1,29 @@
+package se.assertkth.cs.preprocess;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import se.assertkth.cs.Main;
+
+public class JavaAgentPath {
+    private JavaAgentPath() {}
+
+    /**
+     * Returns the path of the trace-collector.jar file.
+     *
+     * Fetches it from within the collector-sahab-{verison}-jar-with-dependencies.jar
+     * in production environment.
+     */
+    public static String getAgentPath() throws IOException {
+        String tempDir = System.getProperty("java.io.tmpdir");
+        Path traceCollector = Path.of(tempDir, "trace-collector.jar");
+
+        try (InputStream traceCollectorStream = Main.class.getResourceAsStream("/trace-collector.jar")) {
+            Files.copy(traceCollectorStream, traceCollector, StandardCopyOption.REPLACE_EXISTING);
+        }
+
+        return traceCollector.toAbsolutePath().toString();
+    }
+}

--- a/main/src/main/java/se/assertkth/cs/preprocess/PomTransformer.java
+++ b/main/src/main/java/se/assertkth/cs/preprocess/PomTransformer.java
@@ -1,6 +1,6 @@
 package se.assertkth.cs.preprocess;
 
-import static se.assertkth.collector.util.JavaAgentPath.getAgentPath;
+import static se.assertkth.cs.preprocess.JavaAgentPath.getAgentPath;
 
 import java.io.FileReader;
 import java.io.FileWriter;

--- a/main/src/test/java/PomTransformerTest.java
+++ b/main/src/test/java/PomTransformerTest.java
@@ -6,7 +6,7 @@ import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.fail;
-import static se.assertkth.collector.util.JavaAgentPath.getAgentPath;
+import static se.assertkth.cs.preprocess.JavaAgentPath.getAgentPath;
 
 import java.io.FileWriter;
 import java.io.IOException;

--- a/trace-collector/pom.xml
+++ b/trace-collector/pom.xml
@@ -115,6 +115,8 @@
           </filters>
         </configuration>
         <executions>
+          <!--     For creating the agent JAR that will be eventually copied by dependency plugin inside collector-sahab-{version}-jar-with-dependencies.jar. -->
+          <!--          See execution `dep-plug` in main module. -->
           <execution>
             <id>shade</id>
             <goals>
@@ -122,6 +124,7 @@
             </goals>
             <phase>package</phase>
           </execution>
+          <!--          For copying the agent jar into target/classes so that tests can run. -->
           <execution>
             <id>shade-for-test</id>
             <goals>

--- a/trace-collector/src/test/java/NewCollectorTest.java
+++ b/trace-collector/src/test/java/NewCollectorTest.java
@@ -4,7 +4,6 @@ import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
-import static se.assertkth.collector.util.JavaAgentPath.getAgentPath;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -803,7 +802,7 @@ class NewCollectorTest {
         request.setPomFile(pomFile);
         request.setGoals(List.of("clean", "test"));
         request.addArg(testArg);
-        request.addArg("-DargLine=-javaagent:" + getAgentPath() + "=" + String.join(",", agentOptions));
+        request.addArg("-DargLine=-javaagent:" + TestUtil.getAgentPath() + "=" + String.join(",", agentOptions));
 
         // act
         Invoker invoker = new DefaultInvoker();

--- a/trace-collector/src/test/java/TestUtil.java
+++ b/trace-collector/src/test/java/TestUtil.java
@@ -1,5 +1,3 @@
-package se.assertkth.collector.util;
-
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
@@ -7,13 +5,15 @@ import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import se.assertkth.collector.CollectorAgent;
 
-public class JavaAgentPath {
-    private JavaAgentPath() {}
+public class TestUtil {
+    private TestUtil() {}
 
     /**
-     * Returns the path of the trace-collector.jar file in target/classes directory of `trace-collector` module.
+     * Returns the path of the trace-collector.jar file.
+     *
+     * Fetches from target/classes in test environment.
      */
-    public static String getAgentPath() throws IOException {
+    static String getAgentPath() throws IOException {
         String tempDir = System.getProperty("java.io.tmpdir");
         Path traceCollector = Path.of(tempDir, "trace-collector.jar");
 


### PR DESCRIPTION
We need not have trace collector as a dependency in `main` because we already package the agent using the maven dependency plugin.