### PR TITLE
fix: set source and target version as `1.6` if they are `5` or `1.5`

### DIFF
--- a/main/src/main/java/se/assertkth/cs/preprocess/PomTransformer.java
+++ b/main/src/main/java/se/assertkth/cs/preprocess/PomTransformer.java
@@ -212,6 +212,15 @@ public class PomTransformer {
             if (!found) {
                 compilerArgs.addChild(arg);
             }
+
+            Xpp3Dom source = configuration.getChild("source");
+            if (source != null && ("5".equals(source.getValue()) || "1.5".equals(source.getValue()))) {
+                source.setValue("1.6");
+            }
+            Xpp3Dom target = configuration.getChild("target");
+            if (target != null && ("5".equals(target.getValue()) || "1.5".equals(target.getValue()))) {
+                target.setValue("1.6");
+            }
         }
         return configuration;
     }

--- a/main/src/test/java/PomTransformerTest.java
+++ b/main/src/test/java/PomTransformerTest.java
@@ -320,5 +320,27 @@ class PomTransformerTest {
             Xpp3Dom parameters = compilerArgs.getChild(1);
             assertThat(parameters.getValue(), is(equalTo("-parameters")));
         }
+
+        @Test
+        void modifyCompilerPlugin_shouldSet_source_target_to_6_if_5(@TempDir Path tempDir)
+                throws XmlPullParserException, IOException {
+            // arrange;
+            PomTransformer transformer =
+                    new PomTransformer(Paths.get("src/test/resources/compiler/modify-source-target.xml"));
+
+            Plugin compilerPlugin =
+                    transformer.getModel().getBuild().getPlugins().get(0);
+            Xpp3Dom source = ((Xpp3Dom) compilerPlugin.getConfiguration()).getChild("source");
+            assertThat(source.getValue(), is(equalTo("1.5")));
+            Xpp3Dom target = ((Xpp3Dom) compilerPlugin.getConfiguration()).getChild("target");
+            assertThat(target.getValue(), is(equalTo("5")));
+
+            // act
+            transformer.modifyCompilerPlugin();
+
+            // assert
+            assertThat(source.getValue(), is(equalTo("1.6")));
+            assertThat(target.getValue(), is(equalTo("1.6")));
+        }
     }
 }

--- a/main/src/test/resources/compiler/modify-source-target.xml
+++ b/main/src/test/resources/compiler/modify-source-target.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.example</groupId>
+  <artifactId>transform-me</artifactId>
+  <version>1.0-SNAPSHOT</version>
+
+  <properties>
+    <maven.compiler.source>11</maven.compiler.source>
+    <maven.compiler.target>11</maven.compiler.target>
+  </properties>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.11.0</version>
+        <configuration>
+          <compilerArgs>
+            <arg>-nowarn</arg>
+          </compilerArgs>
+          <source>1.5</source>
+          <target>5</target>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>


### PR DESCRIPTION
Fixes #176