### PR TITLE
fix: remove debugging configuration from compiler plugin

### DIFF
--- a/main/src/main/java/se/assertkth/cs/preprocess/PomTransformer.java
+++ b/main/src/main/java/se/assertkth/cs/preprocess/PomTransformer.java
@@ -212,15 +212,25 @@ public class PomTransformer {
             if (!found) {
                 compilerArgs.addChild(arg);
             }
+        }
+        // By default, the compiler plugin compiles debug information.
+        Xpp3Dom debug = configuration.getChild("debug");
+        if (debug != null) {
+            configuration.removeChild(debug);
+        }
 
-            Xpp3Dom source = configuration.getChild("source");
-            if (source != null && ("5".equals(source.getValue()) || "1.5".equals(source.getValue()))) {
-                source.setValue("1.6");
-            }
-            Xpp3Dom target = configuration.getChild("target");
-            if (target != null && ("5".equals(target.getValue()) || "1.5".equals(target.getValue()))) {
-                target.setValue("1.6");
-            }
+        Xpp3Dom debugLevel = configuration.getChild("debuglevel");
+        if (debugLevel != null) {
+            configuration.removeChild(debugLevel);
+        }
+
+        Xpp3Dom source = configuration.getChild("source");
+        if (source != null && ("5".equals(source.getValue()) || "1.5".equals(source.getValue()))) {
+            source.setValue("1.6");
+        }
+        Xpp3Dom target = configuration.getChild("target");
+        if (target != null && ("5".equals(target.getValue()) || "1.5".equals(target.getValue()))) {
+            target.setValue("1.6");
         }
         return configuration;
     }

--- a/main/src/test/java/PomTransformerTest.java
+++ b/main/src/test/java/PomTransformerTest.java
@@ -5,6 +5,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static se.assertkth.collector.util.JavaAgentPath.getAgentPath;
 
@@ -341,6 +342,30 @@ class PomTransformerTest {
             // assert
             assertThat(source.getValue(), is(equalTo("1.6")));
             assertThat(target.getValue(), is(equalTo("1.6")));
+        }
+
+        @Test
+        void modifyCompilerPlugin_shouldRemoveDebugConfiguration(@TempDir Path tempDir)
+                throws XmlPullParserException, IOException {
+            // arrange;
+            PomTransformer transformer = new PomTransformer(Paths.get("src/test/resources/compiler/remove-debug.xml"));
+
+            Plugin compilerPlugin =
+                    transformer.getModel().getBuild().getPlugins().get(0);
+            Xpp3Dom debug = ((Xpp3Dom) compilerPlugin.getConfiguration()).getChild("debug");
+            assertThat(debug.getValue(), is(equalTo("true")));
+            Xpp3Dom debugLevel = ((Xpp3Dom) compilerPlugin.getConfiguration()).getChild("debuglevel");
+            assertThat(debugLevel.getValue(), is(equalTo("lines,source")));
+
+            // act
+            transformer.modifyCompilerPlugin();
+
+            // assert
+            Xpp3Dom configuration = (Xpp3Dom) compilerPlugin.getConfiguration();
+            debug = configuration.getChild("debug");
+            debugLevel = configuration.getChild("debuglevel");
+            assertThat(debug, is(nullValue()));
+            assertThat(debugLevel, is(nullValue()));
         }
     }
 }

--- a/main/src/test/resources/compiler/remove-debug.xml
+++ b/main/src/test/resources/compiler/remove-debug.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.example</groupId>
+  <artifactId>basic-math</artifactId>
+  <version>1.0-SNAPSHOT</version>
+
+  <properties>
+    <maven.compiler.source>11</maven.compiler.source>
+    <maven.compiler.target>11</maven.compiler.target>
+  </properties>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.0</version>
+        <configuration>
+          <verbose>true</verbose>
+          <fork>true</fork>
+          <compilerVersion>1.6</compilerVersion>
+          <source>1.6</source>
+          <target>1.6</target>
+          <debug>true</debug>
+          <debuglevel>lines,source</debuglevel>
+          <optimize>true</optimize>
+          <showDeprecation>false</showDeprecation>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>


### PR DESCRIPTION
By default, maven compiler plugin `3.11.0`, compiles with all debugging information. Hence we remove the custom settings.