### PR TITLE
fix: simplify value while serialising

### DIFF
--- a/commons/src/main/java/se/assertkth/cs/commons/runtime/RuntimeReturnedValue.java
+++ b/commons/src/main/java/se/assertkth/cs/commons/runtime/RuntimeReturnedValue.java
@@ -83,7 +83,7 @@ public class RuntimeReturnedValue extends RuntimeValue {
             serializers.defaultSerializeField("methodName", value.getName(), gen);
             serializers.defaultSerializeField("stackTrace", value.getStackTrace(), gen);
             serializers.defaultSerializeField("type", value.getType(), gen);
-            serializers.defaultSerializeField("value", value.getValue(), gen);
+            serializers.defaultSerializeField("value", Classes.simplifyValue(value.getValue()), gen);
             serializers.defaultSerializeField("arrayElements", value.getArrayElements(), gen);
             serializers.defaultSerializeField("fields", value.getFields(), gen);
             serializers.defaultSerializeField("location", value.getLocation(), gen);

--- a/commons/src/main/java/se/assertkth/cs/commons/runtime/RuntimeValue.java
+++ b/commons/src/main/java/se/assertkth/cs/commons/runtime/RuntimeValue.java
@@ -123,7 +123,7 @@ public class RuntimeValue {
             serializers.defaultSerializeField("name", value.name, gen);
             serializers.defaultSerializeField("type", value.type, gen);
             serializers.defaultSerializeField("fields", value.fields, gen);
-            serializers.defaultSerializeField("value", value.value, gen);
+            serializers.defaultSerializeField("value", Classes.simplifyValue(value.value), gen);
             serializers.defaultSerializeField("arrayElements", value.arrayElements, gen);
             gen.writeEndObject();
         }


### PR DESCRIPTION
Somehow serialisation was breaking for this [patch](https://github.com/ASSERT-KTH/collector-sahab-experiments/commit/20e5b8c). I am not sure why.

**Command to reproduce**
```sh
java -jar /home/aman/assert-achievements/collector-sahab/main/target/collector-sahab-0.1.3-SNAPSHOT-jar-with-dependencies.jar  -p /home/aman/experiments/drr-execdiff/Time-11 -c src/main/java/org/joda/time/tz/DateTimeZoneBuilder.java -l e5d67a8 -r 20e5b8c28c217749dbba407416cae169df3c3fd7 --slug 'ASSERT-KTH/collector-sahab-experiments' --execution-depth 2 --selected-tests "org.joda.time.tz.TestCompiler#testDateTimeZoneBuilder"
```