### PR TITLE
fix: clone the first `20` elements of array

### DIFF
--- a/commons/src/main/java/io/github/chains_project/cs/commons/util/Classes.java
+++ b/commons/src/main/java/io/github/chains_project/cs/commons/util/Classes.java
@@ -101,8 +101,10 @@ public class Classes {
     }
 
     public static Object cloneArray(Object array) {
-        int length = Array.getLength(array);
+        // We only clone the first 20 elements, because we don't want to clone huge arrays.
+        int length = Math.min(Array.getLength(array), 20);
         Object clonedArray = Array.newInstance(array.getClass().getComponentType(), length);
+        // ToDo: get this from `numberOfArrayElements` parameter
         for (int i = 0; i < length; i++) {
             Array.set(clonedArray, i, Array.get(array, i));
         }

--- a/trace-collector/src/test/resources/array-value/pom.xml
+++ b/trace-collector/src/test/resources/array-value/pom.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.example</groupId>
+  <artifactId>array-value</artifactId>
+  <version>1.0-SNAPSHOT</version>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>3.0.0</version>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.11.0</version>
+      </plugin>
+    </plugins>
+  </build>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <version>5.8.2</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/trace-collector/src/test/resources/array-value/src/test/java/ArrayValueTest.java
+++ b/trace-collector/src/test/resources/array-value/src/test/java/ArrayValueTest.java
@@ -1,0 +1,13 @@
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+
+class ArrayValueTest {
+    @Test
+    public void test() {
+        int[] array = new int[42];
+        Arrays.fill(array, 42);
+        assert array[0] == 42;
+        assert array[41] == 42;
+    }
+}

--- a/trace-collector/src/test/resources/array-value/src/test/resources/input.txt
+++ b/trace-collector/src/test/resources/array-value/src/test/resources/input.txt
@@ -1,0 +1,6 @@
+[
+    {
+        "fileName": "ArrayValueTest",
+        "breakpoints": [10]
+    }
+]


### PR DESCRIPTION
We were limiting the number of elements in the array in `arrayElements` only, but we also need to do the same in `value`. The changes fix that.