### PR TITLE
feat: add option to clean up generated directories after JVM exit

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ And finally, a maven project hosted on GitHub. :smile:
    1. `--selected-test` (list of tests separated by comma): The tests to be executed. Default is `[]` which
       runs every test in the target project.
    2. `--output-path` (string): The path where the output will be stored. Default is `output.html`.
+   3. `--cleanup` (boolean): Whether to clean up the temporary files created during execution. Default is `false`.
 
    Following parameters have not been added to `main`, but planned to be added in the future if needed.
    


### PR DESCRIPTION
@khaes-kth add `--cleanup` option to the arguments, and it will clean up the directories on `System.exit` or `^C` - JVM termination basically.

The default is `false` because it is useful to have them for debugging afterwards.