### PR TITLE
fix: remove instrumentation of throw instruction

### DIFF
--- a/trace-collector/src/main/java/io/github/chains_project/collector/CollectorAgent.java
+++ b/trace-collector/src/main/java/io/github/chains_project/collector/CollectorAgent.java
@@ -1,6 +1,5 @@
 package io.github.chains_project.collector;
 
-import static org.objectweb.asm.Opcodes.ATHROW;
 import static org.objectweb.asm.Opcodes.IRETURN;
 import static org.objectweb.asm.Opcodes.RETURN;
 
@@ -186,7 +185,7 @@ public class CollectorAgent {
     }
 
     private static boolean isItExitInstruction(int opCode) {
-        return (opCode >= IRETURN && opCode <= RETURN) || opCode == ATHROW;
+        return (opCode >= IRETURN && opCode <= RETURN);
     }
 
     private static StackManipulation.Compound getCallToEntryLogMethod(MethodNode method) throws NoSuchMethodException {


### PR DESCRIPTION
Fixes #201 

The changes remove instrumentation of `throw` because an `getLogReturn` expects the return type of the method on top of the stack, however it receives a type of exception and hence it fails.

If we want to instrument `throw`, we need to make sure we instrument with the correct type of exception.

**Bytecode**

```sh
LINENUMBER 102 L1
   FRAME SAME
    NEW org/apache/commons/math3/exception/OutOfRangeException
    DUP
    DLOAD 1
    INVOKESTATIC java/lang/Double.valueOf (D)Ljava/lang/Double;
    ICONST_0
    INVOKESTATIC java/lang/Integer.valueOf (I)Ljava/lang/Integer;
    ICONST_1
    INVOKESTATIC java/lang/Integer.valueOf (I)Ljava/lang/Integer;
    INVOKESPECIAL org/apache/commons/math3/exception/OutOfRangeException.<init> (Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;)V
    DUP
    INVOKESTATIC java/lang/Integer.valueOf (I)Ljava/lang/Integer;
    LDC "inverseCumulativeProbability"
    GETSTATIC java/lang/Integer.TYPE : Ljava/lang/Class;
    LDC "org.apache.commons.math3.distribution.AbstractIntegerDistribution"
    INVOKESTATIC java/lang/Class.forName (Ljava/lang/String;)Ljava/lang/Class;
    ALOAD 54
    INVOKESTATIC io/github/chains_project/collector/util/ContextCollector.logReturn (Ljava/lang/Object;Ljava/lang/String;Ljava/lang/Class;Ljava/lang/Class;Ljava/util/List;)V
    ATHROW
```

**Source Code**

https://github.com/ASSERT-KTH/collector-sahab-experiments/blob/4601a1dc0f9e8b5a616019fde76291dd3f7e33d7/Math-2/src/main/java/org/apache/commons/math3/distribution/AbstractIntegerDistribution.java#L101-L103