### PR TITLE
fix: update versions for maven.compile(r)

### DIFF
--- a/main/src/main/java/io/github/chains_project/cs/preprocess/PomTransformer.java
+++ b/main/src/main/java/io/github/chains_project/cs/preprocess/PomTransformer.java
@@ -66,13 +66,25 @@ public class PomTransformer {
         if (mavenCompilerCompilerVersion != null && OLD_COMPILER_VERSIONS.contains(mavenCompilerCompilerVersion)) {
             properties.setProperty("maven.compiler.compilerVersion", "1.6");
         }
+        String mavenCompileCompilerVersion = properties.getProperty("maven.compile.compilerVersion");
+        if (mavenCompileCompilerVersion != null && OLD_COMPILER_VERSIONS.contains(mavenCompileCompilerVersion)) {
+            properties.setProperty("maven.compile.compilerVersion", "1.6");
+        }
         String mavenCompilerSource = properties.getProperty("maven.compiler.source");
         if (mavenCompilerSource != null && OLD_COMPILER_VERSIONS.contains(mavenCompilerSource)) {
             properties.setProperty("maven.compiler.source", "1.6");
         }
+        String mavenCompileSource = properties.getProperty("maven.compile.source");
+        if (mavenCompileSource != null && OLD_COMPILER_VERSIONS.contains(mavenCompileSource)) {
+            properties.setProperty("maven.compile.source", "1.6");
+        }
         String mavenCompilerTarget = properties.getProperty("maven.compiler.target");
         if (mavenCompilerTarget != null && OLD_COMPILER_VERSIONS.contains(mavenCompilerTarget)) {
             properties.setProperty("maven.compiler.target", "1.6");
+        }
+        String mavenCompileTarget = properties.getProperty("maven.compile.target");
+        if (mavenCompileTarget != null && OLD_COMPILER_VERSIONS.contains(mavenCompileTarget)) {
+            properties.setProperty("maven.compile.target", "1.6");
         }
     }
 


### PR DESCRIPTION
Apparently, you can declare `maven.compiler.source` or `maven.compile.source`. :facepalm:

For example: https://github.com/ASSERT-KTH/collector-sahab-experiments/blob/4601a1dc0f9e8b5a616019fde76291dd3f7e33d7/Math-20/pom.xml#L300