### PR TITLE
test: add test to verify collection of data for null objects

### DIFF
--- a/trace-collector/src/test/resources/volatile/pom.xml
+++ b/trace-collector/src/test/resources/volatile/pom.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.example</groupId>
+    <artifactId>volatile</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <properties>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.0.0</version>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.8.2</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/trace-collector/src/test/resources/volatile/src/main/java/gas/Volatile.java
+++ b/trace-collector/src/test/resources/volatile/src/main/java/gas/Volatile.java
@@ -1,0 +1,6 @@
+package gas;
+
+public class Volatile {
+    static int x = 1;
+    static volatile boolean y = false;
+}

--- a/trace-collector/src/test/resources/volatile/src/test/java/VolatileTest.java
+++ b/trace-collector/src/test/resources/volatile/src/test/java/VolatileTest.java
@@ -1,0 +1,13 @@
+import gas.Volatile;
+import org.junit.jupiter.api.Test;
+
+class VolatileTest {
+    @Test
+    void test() {
+        Volatile vNonNull = new Volatile();
+        Volatile vNull = null;
+        if (vNull == null) {
+            System.out.println("vNull is null");
+        }
+    }
+}

--- a/trace-collector/src/test/resources/volatile/src/test/resources/input.txt
+++ b/trace-collector/src/test/resources/volatile/src/test/resources/input.txt
@@ -1,0 +1,6 @@
+[
+    {
+        "fileName": "VolatileTest",
+        "breakpoints": [9]
+    }
+]


### PR DESCRIPTION
@khaes-kth the changes add a test which shows that we also collect data for objects whose value is `null`.