### PR TITLE
test: add case to observe how multi-threading works out

### DIFF
--- a/trace-collector/src/test/java/NewCollectorTest.java
+++ b/trace-collector/src/test/java/NewCollectorTest.java
@@ -994,6 +994,30 @@ class NewCollectorTest {
         assertThat(volatileField.getValue(), equalTo(false));
     }
 
+    @Test
+    void test() throws MavenInvocationException, IOException {
+        // arrange
+        File pomFile = new File("src/test/resources/multi-threading/pom.xml");
+
+        // act
+        InvocationResult result = getInvocationResult(
+                pomFile,
+                List.of(
+                        "classesAndBreakpoints=src/test/resources/input.txt",
+                        "output=target/output.json",
+                        "executionDepth=0"),
+                "-Dtest=MultipleThreadTest#test");
+
+        // assert
+        assertThat(result.getExitCode(), equalTo(0));
+        File actualOutput = new File("src/test/resources/multi-threading/target/output.json");
+        assertThat(actualOutput.exists(), equalTo(true));
+
+        ObjectMapper mapper = new ObjectMapper();
+        SahabOutput output = mapper.readValue(actualOutput, new TypeReference<>() {});
+        assertThat(output.getBreakpoint().size(), equalTo(4));
+    }
+
     private InvocationResult getInvocationResult(File pomFile, List<String> agentOptions, String testArg)
             throws MavenInvocationException, IOException {
         // arrange

--- a/trace-collector/src/test/resources/multi-threading/pom.xml
+++ b/trace-collector/src/test/resources/multi-threading/pom.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.example</groupId>
+  <artifactId>multi-threading</artifactId>
+  <version>1.0-SNAPSHOT</version>
+
+  <properties>
+    <maven.compiler.source>11</maven.compiler.source>
+    <maven.compiler.target>11</maven.compiler.target>
+  </properties>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>3.0.0</version>
+      </plugin>
+    </plugins>
+  </build>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <version>5.8.2</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/trace-collector/src/test/resources/multi-threading/src/main/java/foo/MultipleThread.java
+++ b/trace-collector/src/test/resources/multi-threading/src/main/java/foo/MultipleThread.java
@@ -1,0 +1,32 @@
+package foo;
+
+public class MultipleThread {
+    public static void main(String[] args) {
+        int n = 4; // Number of threads
+        for (int i = 0; i < n; i++) {
+            OneThread object = new OneThread(i);
+            object.start();
+        }
+    }
+}
+
+class OneThread extends Thread {
+    final int threadIndex;
+    long threadId;
+
+    OneThread(int threadIndex) {
+        this.threadIndex = threadIndex;
+    }
+
+    public void run() {
+        try {
+            // Displaying the thread that is running
+            threadId = Thread.currentThread().getId();
+            System.out.println("Thread " + threadId + " is running which was assigned at index " + threadIndex);
+        }
+        catch (Exception e) {
+            // Throwing an exception
+            System.out.println("Exception is caught");
+        }
+    }
+}

--- a/trace-collector/src/test/resources/multi-threading/src/test/java/MultipleThreadTest.java
+++ b/trace-collector/src/test/resources/multi-threading/src/test/java/MultipleThreadTest.java
@@ -1,0 +1,9 @@
+import foo.MultipleThread;
+import org.junit.jupiter.api.Test;
+
+class MultipleThreadTest {
+    @Test
+    void test() {
+        MultipleThread.main(new String[0]);
+    }
+}

--- a/trace-collector/src/test/resources/multi-threading/src/test/resources/input.txt
+++ b/trace-collector/src/test/resources/multi-threading/src/test/resources/input.txt
@@ -1,0 +1,6 @@
+[
+    {
+        "fileName": "foo/OneThread",
+        "breakpoints": [25]
+    }
+]


### PR DESCRIPTION
I started this pull request to tackle #244. However, I observe that upon running the test _without instrumentation, statements are printed out to STDOUT. On the other hand, the same statements disappear when I instrument.

**Without Instrumentation**

```
[INFO] Scanning for projects...
[INFO] 
[INFO] --------------------< org.example:multi-threading >---------------------
[INFO] Building multi-threading 1.0-SNAPSHOT
[INFO]   from pom.xml
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- resources:3.3.0:resources (default-resources) @ multi-threading ---
[WARNING] Using platform encoding (UTF-8 actually) to copy filtered resources, i.e. build is platform dependent!
[INFO] skip non existing resourceDirectory /home/aman/assert-achievements/collector-sahab/trace-collector/src/test/resources/multi-threading/src/main/resources
[INFO] 
[INFO] --- compiler:3.10.1:compile (default-compile) @ multi-threading ---
[INFO] Nothing to compile - all classes are up to date
[INFO] 
[INFO] --- resources:3.3.0:testResources (default-testResources) @ multi-threading ---
[WARNING] Using platform encoding (UTF-8 actually) to copy filtered resources, i.e. build is platform dependent!
[INFO] Copying 1 resource
[INFO] 
[INFO] --- compiler:3.10.1:testCompile (default-testCompile) @ multi-threading ---
[INFO] Nothing to compile - all classes are up to date
[INFO] 
[INFO] --- surefire:3.0.0:test (default-test) @ multi-threading ---
[INFO] Using auto detected provider org.apache.maven.surefire.junitplatform.JUnitPlatformProvider
[INFO] 
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running MultipleThreadTest
Thread 17 is running which was assigned at index 1
Thread 18 is running which was assigned at index 2
Thread 16 is running which was assigned at index 0
Thread 19 is running which was assigned at index 3
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.064 s - in MultipleThreadTest
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  1.664 s
[INFO] Finished at: 2023-05-17T10:50:11+02:00
[INFO] ------------------------------------------------------------------------
```

**With Instrumentation**

```
[INFO] Scanning for projects...
[INFO] 
[INFO] --------------------< org.example:multi-threading >---------------------
[INFO] Building multi-threading 1.0-SNAPSHOT
[INFO]   from pom.xml
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- clean:3.2.0:clean (default-clean) @ multi-threading ---
[INFO] Deleting /home/aman/assert-achievements/collector-sahab/trace-collector/src/test/resources/multi-threading/target
[INFO] 
[INFO] --- resources:3.3.0:resources (default-resources) @ multi-threading ---
[WARNING] Using platform encoding (UTF-8 actually) to copy filtered resources, i.e. build is platform dependent!
[INFO] skip non existing resourceDirectory /home/aman/assert-achievements/collector-sahab/trace-collector/src/test/resources/multi-threading/src/main/resources
[INFO] 
[INFO] --- compiler:3.10.1:compile (default-compile) @ multi-threading ---
[INFO] Changes detected - recompiling the module!
[WARNING] File encoding has not been set, using platform encoding UTF-8, i.e. build is platform dependent!
[INFO] Compiling 1 source file to /home/aman/assert-achievements/collector-sahab/trace-collector/src/test/resources/multi-threading/target/classes
[INFO] 
[INFO] --- resources:3.3.0:testResources (default-testResources) @ multi-threading ---
[WARNING] Using platform encoding (UTF-8 actually) to copy filtered resources, i.e. build is platform dependent!
[INFO] Copying 1 resource
[INFO] 
[INFO] --- compiler:3.10.1:testCompile (default-testCompile) @ multi-threading ---
[INFO] Changes detected - recompiling the module!
[WARNING] File encoding has not been set, using platform encoding UTF-8, i.e. build is platform dependent!
[INFO] Compiling 1 source file to /home/aman/assert-achievements/collector-sahab/trace-collector/src/test/resources/multi-threading/target/test-classes
[INFO] 
[INFO] --- surefire:3.0.0:test (default-test) @ multi-threading ---
[INFO] Using auto detected provider org.apache.maven.surefire.junitplatform.JUnitPlatformProvider
[INFO] 
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running MultipleThreadTest
WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by io.github.chains_project.collector.util.ObjectIntrospection (file:/tmp/trace-collector.jar) to field java.lang.Thread.name
WARNING: Please consider reporting this to the maintainers of io.github.chains_project.collector.util.ObjectIntrospection
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.142 s - in MultipleThreadTest
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  2.721 s
[INFO] Finished at: 2023-05-17T10:55:57+02:00
[INFO] ------------------------------------------------------------------------

Process finished with exit code 0

```

Notice the missing `Thread <thread_id> is running which was assigned at index <thread_index>` statements in STDOUT.