### PR TITLE
chore: run jobs for multiple maven versions

### DIFF
--- a/.github/workflows/it.yml
+++ b/.github/workflows/it.yml
@@ -9,16 +9,23 @@ jobs:
   test:
     runs-on: ubuntu-latest
 
+    strategy:
+      matrix:
+        maven: [ '3.6.3', '3.9.2' ]
+
+    name: Running integration tests on ${{ matrix.maven }}
+
     steps:
       - uses: actions/checkout@v3
         with:
           submodules: true
           fetch-depth: 0
-      - name: Set up JDK 11 for running tests
-        uses: actions/setup-java@v3
+      - name: Set up JDK 11 and maven for running tests
+        uses: s4u/setup-maven-action@v1.8.0
         with:
           java-version: 11
           distribution: 'temurin'
+          maven-version: ${{ matrix.maven }}
       - name: Install chromium
         run: 'sudo apt-get install chromium-chromedriver -y'
       - name: Prepare all poms

--- a/.github/workflows/it.yml
+++ b/.github/workflows/it.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         maven: [ '3.6.3', '3.9.2' ]
 
-    name: Running integration tests on ${{ matrix.maven }}
+    name: maven ${{ matrix.maven }}
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/sbom-monitor.yml
+++ b/.github/workflows/sbom-monitor.yml
@@ -53,13 +53,16 @@ jobs:
           DIFF: ${{ env.DIFF }}
         run: |
           CONTENT="
+          { \"body\": \"## SBOM diff
+          
             \`\`\`diff
             $(cat $DIFF)
-            \`\`\`"
+            \`\`\`
+          }"  
           echo $CONTENT
           curl \
             -X POST \
             $URL \
             -H "Content-Type: application/json" \
             -H "Authorization: token $GITHUB_TOKEN" \
-            --data '{ "body": "'"$(echo $CONTENT)"'" }'
+            --data "$CONTENT"

--- a/.github/workflows/sbom-monitor.yml
+++ b/.github/workflows/sbom-monitor.yml
@@ -57,4 +57,4 @@ jobs:
             $URL \
             -H "Content-Type: application/json" \
             -H "Authorization: token $GITHUB_TOKEN" \
-            --data '{ "body": $(cat $DIFF) }'
+            --data '{ "body": "$(cat $DIFF)" }'

--- a/.github/workflows/sbom-monitor.yml
+++ b/.github/workflows/sbom-monitor.yml
@@ -56,7 +56,7 @@ jobs:
           { \"body\": \"## SBOM diff
           
             \`\`\`diff
-            $(cat $DIFF)
+            $(cat $DIFF | sed 's/"/\\\"/g'')
             \`\`\`
           }"  
           echo $CONTENT

--- a/.github/workflows/sbom-monitor.yml
+++ b/.github/workflows/sbom-monitor.yml
@@ -52,8 +52,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DIFF: ${{ env.DIFF }}
         run: |
-          CONTENT="
-          { \"body\": \"## SBOM diff
+          CONTENT="{ \"body\": \"## SBOM diff
           
             \`\`\`diff
             $(cat $DIFF | sed 's/"/\\\"/g')

--- a/.github/workflows/sbom-monitor.yml
+++ b/.github/workflows/sbom-monitor.yml
@@ -55,7 +55,7 @@ jobs:
           CONTENT="{ \"body\": \"## SBOM diff\n
             \`\`\`diff\n
             $(cat $DIFF | sed 's/"/\\\"/g')\n
-            \`\`\`\\n"
+            \`\`\`\\n\"
           }"
           echo $CONTENT
           echo $URL

--- a/.github/workflows/sbom-monitor.yml
+++ b/.github/workflows/sbom-monitor.yml
@@ -52,13 +52,14 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DIFF: ${{ env.DIFF }}
         run: |
-          CONTENT="### SBOM comparison
+          CONTENT="
             \`\`\`diff
             $(cat $DIFF)
             \`\`\`"
+          echo $CONTENT
           curl \
             -X POST \
             $URL \
             -H "Content-Type: application/json" \
             -H "Authorization: token $GITHUB_TOKEN" \
-            --data '{ "body": "'"$(cat $DIFF)"'" }'
+            --data '{ "body": "'"$(echo $CONTENT)"'" }'

--- a/.github/workflows/sbom-monitor.yml
+++ b/.github/workflows/sbom-monitor.yml
@@ -55,7 +55,7 @@ jobs:
           CONTENT="{ \"body\": \"## SBOM diff
           
             \`\`\`diff
-            $(cat $DIFF | sed 's/"/\\\"/g'; s/{/\\{/g'; s/}/\\}/g')
+            $(cat $DIFF | sed 's/"/\\\"/g; s/{/\\{/g; s/}/\\}/g')
             \`\`\`
           }"  
           echo $CONTENT

--- a/.github/workflows/sbom-monitor.yml
+++ b/.github/workflows/sbom-monitor.yml
@@ -60,6 +60,8 @@ jobs:
           echo $CONTENT
           echo $URL
           curl \
+            -v \
+            --trace-ascii \
             -X POST \
             $URL \
             -H "Content-Type: application/json" \

--- a/.github/workflows/sbom-monitor.yml
+++ b/.github/workflows/sbom-monitor.yml
@@ -61,4 +61,9 @@ jobs:
             $URL \
             -H "Content-Type: application/json" \
             -H "Authorization: token $GITHUB_TOKEN" \
-            --data '{ "body": "$CONTENT" }'
+            --data @<(cat <<EOF
+              {
+                "body": "$CONTENT"
+              }
+            EOF
+            )

--- a/.github/workflows/sbom-monitor.yml
+++ b/.github/workflows/sbom-monitor.yml
@@ -52,12 +52,11 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DIFF: ${{ env.DIFF }}
         run: |
-          CONTENT="{ \"body\": \"## SBOM diff
-          
-            \`\`\`diff
-            $(cat $DIFF | sed 's/"/\\\"/g')
-            \`\`\`\"
-          }"  
+          CONTENT="{ \"body\": \"## SBOM diff\n
+            \`\`\`diff\n
+            $(cat $DIFF | sed 's/"/\\\"/g')\n
+            \`\`\`\\n"
+          }"
           echo $CONTENT
           echo $URL
           curl \

--- a/.github/workflows/sbom-monitor.yml
+++ b/.github/workflows/sbom-monitor.yml
@@ -55,7 +55,7 @@ jobs:
           CONTENT="{ \"body\": \"## SBOM diff
           
             \`\`\`diff
-            $(cat $DIFF | sed 's/"/\\\"/g')
+            $(cat $DIFF | sed 's/"/\\\"/g'; s/{/\\{/g'; s/}/\\}/g')
             \`\`\`
           }"  
           echo $CONTENT

--- a/.github/workflows/sbom-monitor.yml
+++ b/.github/workflows/sbom-monitor.yml
@@ -52,15 +52,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DIFF: ${{ env.DIFF }}
         run: |
-          read -r -d '' FORMATTED_DIFF << EOL
-            \\\`\\\`\\\`diff
-            $(cat $DIFF)
-            \\\`\\\`\\\`
-          EOL
-  
           curl \
             -X POST \
             $URL \
             -H "Content-Type: application/json" \
             -H "Authorization: token $GITHUB_TOKEN" \
-            --data '{ "body": "$FORMATTED_DIFF" }'
+            --data '{ "body": $(cat $DIFF) }'

--- a/.github/workflows/sbom-monitor.yml
+++ b/.github/workflows/sbom-monitor.yml
@@ -43,7 +43,7 @@ jobs:
           HEAD: ${{ env.HEAD }}
           BASE: ${{ env.BASE }}
         run: |
-          git diff --no-index $BASE $HEAD > diff.txt
+          git diff --no-index $BASE $HEAD > diff.txt || true
           cat diff.txt
           echo "DIFF=$(cat diff.txt)" >> $GITHUB_ENV
 

--- a/.github/workflows/sbom-monitor.yml
+++ b/.github/workflows/sbom-monitor.yml
@@ -61,9 +61,8 @@ jobs:
           echo $URL
           curl \
             -v \
-            --trace-ascii \
-            -X POST \
-            $URL \
             -H "Content-Type: application/json" \
             -H "Authorization: token $GITHUB_TOKEN" \
-            --data-binary "$CONTENT"
+            --data "$CONTENT" \
+            -X POST \
+            $URL

--- a/.github/workflows/sbom-monitor.yml
+++ b/.github/workflows/sbom-monitor.yml
@@ -61,8 +61,7 @@ jobs:
           echo $URL
           curl \
             -v \
-            -H "Content-Type: application/json" \
+            -H "Accept: application/vnd.github+json" \
             -H "Authorization: token $GITHUB_TOKEN" \
             --data "$CONTENT" \
-            -X POST \
             $URL

--- a/.github/workflows/sbom-monitor.yml
+++ b/.github/workflows/sbom-monitor.yml
@@ -53,9 +53,9 @@ jobs:
           DIFF: ${{ env.DIFF }}
         run: |
           read -r -d '' FORMATTED_DIFF << EOL
-            ```diff
+            \\\`\\\`\\\`diff
             $(cat $DIFF)
-            ```
+            \\\`\\\`\\\`
           EOL
   
           curl \

--- a/.github/workflows/sbom-monitor.yml
+++ b/.github/workflows/sbom-monitor.yml
@@ -52,9 +52,13 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DIFF: ${{ env.DIFF }}
         run: |
+          CONTENT="### SBOM comparison
+            \`\`\`diff
+            $(cat $DIFF)
+            \`\`\`"
           curl \
             -X POST \
             $URL \
             -H "Content-Type: application/json" \
             -H "Authorization: token $GITHUB_TOKEN" \
-            --data '{ "body": "$(cat $DIFF)" }'
+            --data '{ "body": "$CONTENT" }'

--- a/.github/workflows/sbom-monitor.yml
+++ b/.github/workflows/sbom-monitor.yml
@@ -55,7 +55,7 @@ jobs:
           CONTENT="{ \"body\": \"## SBOM diff
           
             \`\`\`diff
-            $(cat $DIFF | sed 's/"/\\\"/g; s/{/\\{/g; s/}/\\}/g')
+            $(cat $DIFF | sed 's/"/\\\"/g; s/{/\\{/g; s/}/\\}/g; s/[/\\[/g; s/]/\\]/g')
             \`\`\`
           }"  
           echo $CONTENT

--- a/.github/workflows/sbom-monitor.yml
+++ b/.github/workflows/sbom-monitor.yml
@@ -66,4 +66,4 @@ jobs:
             $URL \
             -H "Content-Type: application/json" \
             -H "Authorization: token $GITHUB_TOKEN" \
-            --data "$CONTENT"
+            --data-binary "$CONTENT"

--- a/.github/workflows/sbom-monitor.yml
+++ b/.github/workflows/sbom-monitor.yml
@@ -61,9 +61,4 @@ jobs:
             $URL \
             -H "Content-Type: application/json" \
             -H "Authorization: token $GITHUB_TOKEN" \
-            --data @<(cat <<EOF
-              {
-                "body": "$CONTENT"
-              }
-            EOF
-            )
+            --data '{ "body": "'"$(cat $DIFF)"'" }'

--- a/.github/workflows/sbom-monitor.yml
+++ b/.github/workflows/sbom-monitor.yml
@@ -44,8 +44,7 @@ jobs:
           BASE: ${{ env.BASE }}
         run: |
           git diff --no-index $BASE $HEAD > diff.txt || true
-          cat diff.txt
-          echo "DIFF=$(cat diff.txt)" >> $GITHUB_ENV
+          echo "DIFF=$(realpath diff.txt)" >> $GITHUB_ENV
 
       - name: Post comment to PR
         env:
@@ -55,7 +54,7 @@ jobs:
         run: |
           read -r -d '' FORMATTED_DIFF << EOL
             ```diff
-            $DIFF
+            $(cat $DIFF)
             ```
           EOL
   

--- a/.github/workflows/sbom-monitor.yml
+++ b/.github/workflows/sbom-monitor.yml
@@ -56,7 +56,7 @@ jobs:
           { \"body\": \"## SBOM diff
           
             \`\`\`diff
-            $(cat $DIFF | sed 's/"/\\\"/g'')
+            $(cat $DIFF | sed 's/"/\\\"/g')
             \`\`\`
           }"  
           echo $CONTENT

--- a/.github/workflows/sbom-monitor.yml
+++ b/.github/workflows/sbom-monitor.yml
@@ -55,10 +55,11 @@ jobs:
           CONTENT="{ \"body\": \"## SBOM diff
           
             \`\`\`diff
-            $(cat $DIFF | sed 's/"/\\\"/g; s/{/\\{/g; s/}/\\}/g; s/[/\\[/g; s/]/\\]/g')
-            \`\`\`
+            $(cat $DIFF | sed 's/"/\\\"/g')
+            \`\`\`\"
           }"  
           echo $CONTENT
+          echo $URL
           curl \
             -X POST \
             $URL \

--- a/.github/workflows/sbom-monitor.yml
+++ b/.github/workflows/sbom-monitor.yml
@@ -43,9 +43,9 @@ jobs:
           HEAD: ${{ env.HEAD }}
           BASE: ${{ env.BASE }}
         run: |
-          DIFF=$(git diff --no-index $BASE $HEAD)
-          echo "$DIFF"
-          echo "DIFF=$DIFF" >> $GITHUB_ENV
+          git diff --no-index $BASE $HEAD > diff.txt
+          cat diff.txt
+          echo "DIFF=$(cat diff.txt)" >> $GITHUB_ENV
 
       - name: Post comment to PR
         env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,9 +11,9 @@ jobs:
 
     strategy:
       matrix:
-        maven: ['3.6.3', '3.9.2']
+        maven: [ '3.6.3', '3.9.2' ]
 
-    name: Running tests on ${{ matrix.maven }}
+    name: maven ${{ matrix.maven }}
 
     steps:
       - name: Set up JDK 11 and maven for running tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,13 +9,19 @@ jobs:
   test:
     runs-on: ubuntu-latest
 
+    strategy:
+      matrix:
+        maven: ['3.6.3', '3.9.2']
+
+    name: Running tests on ${{ matrix.maven }}
+
     steps:
-      - uses: actions/checkout@v3
-      - name: Set up JDK 11 for running tests
-        uses: actions/setup-java@v3
+      - name: Set up JDK 11 and maven for running tests
+        uses: s4u/setup-maven-action@v1.8.0
         with:
           java-version: 11
           distribution: 'temurin'
+          maven-version: ${{ matrix.maven }}
       - name: Style check using spotless
         run: 'mvn spotless:check'
       - name: Prepare all poms


### PR DESCRIPTION
Fixes #200 

The changes run the CI jobs for `mvn` version `3.6.3` and `3.9.2`.