### PR TITLE
ci: Update GitHub Actions workflows to test with multiple Maven versions

### DIFF
--- a/.github/workflows/it.yml
+++ b/.github/workflows/it.yml
@@ -9,16 +9,23 @@ jobs:
   test:
     runs-on: ubuntu-latest
 
+    strategy:
+      matrix:
+        maven: [ '3.6.3', '3.9.2' ]
+
+    name: maven ${{ matrix.maven }}
+
     steps:
       - uses: actions/checkout@v3
         with:
           submodules: true
           fetch-depth: 0
-      - name: Set up JDK 11 for running tests
-        uses: actions/setup-java@v3
+      - name: Set up JDK 11 and maven for running tests
+        uses: s4u/setup-maven-action@v1.8.0
         with:
           java-version: 11
           distribution: 'temurin'
+          maven-version: ${{ matrix.maven }}
       - name: Install chromium
         run: 'sudo apt-get install chromium-chromedriver -y'
       - name: Prepare all poms

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,13 +9,19 @@ jobs:
   test:
     runs-on: ubuntu-latest
 
+    strategy:
+      matrix:
+        maven: [ '3.6.3', '3.9.2' ]
+
+    name: maven ${{ matrix.maven }}
+
     steps:
-      - uses: actions/checkout@v3
-      - name: Set up JDK 11 for running tests
-        uses: actions/setup-java@v3
+      - name: Set up JDK 11 and maven for running tests
+        uses: s4u/setup-maven-action@v1.8.0
         with:
           java-version: 11
           distribution: 'temurin'
+          maven-version: ${{ matrix.maven }}
       - name: Style check using spotless
         run: 'mvn spotless:check'
       - name: Prepare all poms


### PR DESCRIPTION
Fixes #200 

The workflows in .github/workflows/tests.yml and .github/workflows/it.yml have been updated to test with multiple Maven versions, specifically 3.6.3 and 3.9.2. This is achieved by adding a matrix strategy. Also, the actions/setup-java@v3 step has been replaced with s4u/setup-maven-action@v1.8.0 in order to set up both JDK 11 and Maven. This ensures our code is compatible with different Maven versions.