### PR TITLE
fix: shade fasterxml dependency

### DIFF
--- a/trace-collector/pom.xml
+++ b/trace-collector/pom.xml
@@ -89,6 +89,10 @@
           </transformers>
           <relocations>
             <relocation>
+              <pattern>com.fasterxml.jackson</pattern>
+              <shadedPattern>rtf.com.fasterxml.jackson</shadedPattern>
+            </relocation>
+            <relocation>
               <pattern>net.bytebuddy</pattern>
               <shadedPattern>rtf.net.bytebuddy</shadedPattern>
             </relocation>


### PR DESCRIPTION
Reference: #430 

The [error](https://private-user-images.githubusercontent.com/35191225/364128681-a3f75539-6391-45d5-a2e1-ab3503d540d0.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3MjUzOTk3MDMsIm5iZiI6MTcyNTM5OTQwMywicGF0aCI6Ii8zNTE5MTIyNS8zNjQxMjg2ODEtYTNmNzU1MzktNjM5MS00NWQ1LWEyZTEtYWIzNTAzZDU0MGQwLnBuZz9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNDA5MDMlMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjQwOTAzVDIxMzY0M1omWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPTk4NjYwNjc1MGRmZjg5MjU5ODVlNGQwNDk2NWIxMTlhM2E3OTE5NGExODQyMGJmYjc5ZDU1M2FkMDIwODUwNWEmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0JmFjdG9yX2lkPTAma2V5X2lkPTAmcmVwb19pZD0wIn0.7x09whdP4pPgb5yjfMkdjc3ib6mXMHZL52Sgdb6UsQU) is caused by fasterxml dependency conflict. This dependency is in `collector-sahab` and `iotdb`. Apparently, `iotdb` uses an older version of the `fasterxml` and its classes were being used from classpath while trace collection. Since `collector-sahab` needs a newer version, the trace-collector fails after complaining that the API does not exist because the older version is on the classpath. This is a common problem, and to truly mitigate it, we should shade [all of our dependencies](https://github.com/ASSERT-KTH/collector-sahab/blob/main/trace-collector/pom.xml#L14-L63). 

Anyway, the proposed patch fixes the issue in #430.
